### PR TITLE
ci: do not publish edge images on merge to main

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -107,15 +107,8 @@ const pushJob = (event: Event, version?: string) => {
 }
 jobs[pushJobName] = pushJob
 
-// Just build, unless this is a merge to main, then build and push.
 events.on("brigade.sh/github", "ci:pipeline_requested", async event => {
-  if (event.worker?.git?.ref != "main") {
-    // Just build
-    await buildJob(event).run()
-  } else {
-    // Build and push
-    await pushJob(event).run()
-  }
+  await buildJob(event).run()
 })
 
 // This event indicates a specific job is to be re-run.


### PR DESCRIPTION
For quite some time, we've published images tagged with a git sha and "edge" upon every merge to main -- the result being that we use up a _lot_ of storage on DockerHub. Most of these images are never pulled/used, as they _don't_ represent stable, officially released software. As I prepare for the _possibility_ of moving off of DockerHub for various reasons, I'm becoming more conscious of not using up registry space so indiscriminately.

This PR stops us from publishing "edge" images after each merge.